### PR TITLE
Changes to thin startup to use shared pids instead of /var/run because f...

### DIFF
--- a/thin/bin/start
+++ b/thin/bin/start
@@ -14,5 +14,5 @@ exec thin start  \
   --log "$HOME/shared/log/${environment}.log"    \
   --tag ${project}:${environment}  \
   --port ${port} -s2    \
-  --pid /var/run/${project}/thin.pid
+  --pid "$HOME/shared/pids/${project}.pid
 


### PR DESCRIPTION
...older is gone upon bootup
